### PR TITLE
Fix tests and import storage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,6 @@ module.exports = {
     '^.+\\.js$': 'babel-jest'
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(franc|trigram-utils)/)'
+    'node_modules/(?!(franc|trigram-utils|bad-words|badwords-list)/)'
   ]
 }; 

--- a/src/__tests__/integration.test.js
+++ b/src/__tests__/integration.test.js
@@ -1,6 +1,14 @@
+jest.mock('franc', () => () => 'en');
+jest.mock('bad-words', () => {
+  return jest.fn().mockImplementation(() => ({
+    isProfane: () => false
+  }));
+});
+
 const { App } = require('@slack/bolt');
 const ingestion = require('../ingestion');
 const storage = require('../storage');
+const { processQueue } = require('../worker');
 
 // Mock Slack app
 const app = new App({
@@ -39,15 +47,14 @@ describe('Integration Tests', () => {
     }
   });
 
-  test('processes Slack events and extracts tasks', async () => {
+  test('processes Slack events and extracts tasks', () => {
     // Simulate receiving events
     for (const event of mockEvents) {
-      // Manually enqueue the event
       ingestion.enqueue(event);
     }
 
-    // Wait for processing
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    // Process the queue synchronously
+    processQueue();
 
     // Assert tasks are extracted and stored
     const tasks = [];

--- a/src/__tests__/nlp.test.js
+++ b/src/__tests__/nlp.test.js
@@ -1,5 +1,10 @@
 // Mock franc
 jest.mock('franc', () => () => 'en');
+jest.mock('bad-words', () => {
+  return jest.fn().mockImplementation(() => ({
+    isProfane: (text) => /bad/i.test(text)
+  }));
+});
 
 const { runNLP } = require('../worker');
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const { App } = require('@slack/bolt');
 require('dotenv').config();
 const ingestion = require('./ingestion');
+const storage = require('./storage');
 require('./worker');
 require('./dashboard');
 const logger = require('./logger');

--- a/src/worker.js
+++ b/src/worker.js
@@ -94,5 +94,9 @@ function processQueue() {
   }
 }
 
-// Run every second
-setInterval(processQueue, 1000); 
+// Run every second when not under test
+if (process.env.NODE_ENV !== 'test') {
+  setInterval(processQueue, 1000);
+}
+
+module.exports = { runNLP, processQueue };


### PR DESCRIPTION
## Summary
- mock `bad-words` in tests
- expose worker functions and only start queue when not testing
- process queue directly in integration test
- update Jest config to transpile extra modules
- import `storage` in main entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68445288f91c8324881f7607299e194d